### PR TITLE
Enable TypeSense search for rushjs.io

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -114,6 +114,7 @@ importers:
       api-documenter-docusaurus-plugin: workspace:*
       clsx: ^1.1.1
       dayjs: ~1.10.7
+      docusaurus-theme-search-typesense: 0.3.0-0
       file-loader: ^6.2.0
       js-cookie: ~3.0.1
       prism-react-renderer: ^1.2.1
@@ -143,6 +144,7 @@ importers:
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
       api-documenter-docusaurus-plugin: link:../../tools/api-documenter-docusaurus-plugin
+      docusaurus-theme-search-typesense: 0.3.0-0_a9782a83b7daad1a97bf91cabc1c578c
       rehype-headerless-table-plugin: link:../../plugins/rehype-headerless-table-plugin
       remark-canonical-link-plugin: link:../../plugins/remark-canonical-link-plugin
       remark-cross-site-link-plugin: link:../../plugins/remark-cross-site-link-plugin
@@ -8868,7 +8870,7 @@ packages:
       webpack: '>=4.41.1 || 5.x'
     dependencies:
       '@babel/runtime': 7.16.7
-      react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
+      react-loadable: /@docusaurus/react-loadable/5.5.2
       webpack: 5.65.0
 
   /react-router-config/5.1.1_react-router@5.2.1:

--- a/tools/linux-vm/typesense-scraper/rushjs.io-config.json
+++ b/tools/linux-vm/typesense-scraper/rushjs.io-config.json
@@ -1,0 +1,28 @@
+{
+  "index_name": "rushstack.io",
+  "start_urls": ["https://rushjs.io/"],
+  "sitemap_urls": ["https://rushjs.io/sitemap.xml"],
+  "sitemap_alternate_links": true,
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": {
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
+  },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": ["language", "version", "type", "docusaurus_tag"],
+    "attributesToRetrieve": ["hierarchy", "content", "anchor", "url", "url_without_anchor", "type"]
+  }
+}

--- a/websites/rushjs.io/docusaurus.config.js
+++ b/websites/rushjs.io/docusaurus.config.js
@@ -33,6 +33,8 @@ const config = {
   // Deployment settings above can be overriden based on the TARGET determined at runtime
   ...siteConfig.configOverrides,
 
+  themes: ['docusaurus-theme-search-typesense'],
+
   presets: [
     [
       '@docusaurus/preset-classic',
@@ -161,13 +163,25 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme
       },
-      algolia: {
-        appId: 'W2G1E3U5T0',
-        apiKey: 'a0ab6dfc3db0c301b0ca8e725af85641',
-        indexName: 'rushjs.io',
-        searchParameters: {
-          exclusionPatterns: ['pages/api/*']
-        }
+      typesense: {
+        // Replace with your own doc site's name. Should match the collection name in the scraper settings.
+        typesenseCollectionName: 'rushjs.io',
+
+        typesenseServerConfig: {
+          nodes: [
+            {
+              host: 'search.rushstack.io',
+              port: 443,
+              protocol: 'https'
+            }
+          ],
+          apiKey: 'sT4V46j9PmFlJ5MP7IAofccKSpJlOxfF'
+        },
+
+        // Optional: Typesense search parameters: https://typesense.org/docs/0.21.0/api/documents.html#arguments
+        typesenseSearchParameters: {},
+
+        contextualSearch: true
       }
     })
 };

--- a/websites/rushjs.io/package.json
+++ b/websites/rushjs.io/package.json
@@ -41,9 +41,10 @@
     "@types/react-dom": "17.0.11",
     "@types/react": "17.0.37",
     "api-documenter-docusaurus-plugin": "workspace:*",
-    "site-config": "workspace:*",
+    "docusaurus-theme-search-typesense": "0.3.0-0",
+    "rehype-headerless-table-plugin": "workspace:*",
     "remark-canonical-link-plugin": "workspace:*",
     "remark-cross-site-link-plugin": "workspace:*",
-    "rehype-headerless-table-plugin": "workspace:*"
+    "site-config": "workspace:*"
   }
 }


### PR DESCRIPTION
Apply the configuration from `rushstack.io`.   The search box will not be functional until after we have deployed to a staging site that the service can crawl.